### PR TITLE
fix: add MAVLink v1 support to BufferParser

### DIFF
--- a/include/mav/BufferParser.h
+++ b/include/mav/BufferParser.h
@@ -1,35 +1,35 @@
 /****************************************************************************
- * 
+ *
  * Copyright (c) 2023, libmav development team
  * All rights reserved.
- * 
- * Redistribution and use in source and binary forms, with or without 
- * modification, are permitted provided that the following conditions 
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
  * are met:
- * 
- * 1. Redistributions of source code must retain the above copyright 
+ *
+ * 1. Redistributions of source code must retain the above copyright
  *    notice, this list of conditions and the following disclaimer.
- * 2. Redistributions in binary form must reproduce the above copyright 
- *    notice, this list of conditions and the following disclaimer in 
- *    the documentation and/or other materials provided with the 
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
  *    distribution.
- * 3. Neither the name libmav nor the names of its contributors may be 
- *    used to endorse or promote products derived from this software 
+ * 3. Neither the name libmav nor the names of its contributors may be
+ *    used to endorse or promote products derived from this software
  *    without specific prior written permission.
- * 
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS 
- * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT 
- * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS 
- * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE 
- * COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, 
- * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, 
- * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS 
- * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED 
- * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT 
- * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN 
- * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE 
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+ * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
  * POSSIBILITY OF SUCH DAMAGE.
- * 
+ *
  ****************************************************************************/
 
 #ifndef MAV_BUFFERPARSER_H
@@ -47,29 +47,46 @@ namespace mav {
 
     /**
      * @brief Parser for extracting MAVLink messages from raw byte buffers
-     * 
-     * This class provides functionality to parse MAVLink v2 messages from
-     * raw byte data without requiring network interface abstractions.
+     *
+     * Supports both MAVLink v1 (magic byte 0xFE) and MAVLink v2 (magic byte 0xFD).
+     * MAVLink v1 messages are parsed and their payload is presented in the same
+     * Message interface as v2; callers do not need to distinguish between versions.
+     *
      * Based on the StreamParser from Network.h but simplified for buffer parsing.
      */
     class BufferParser {
     private:
         const MessageSet& _message_set;
 
+        [[nodiscard]] std::optional<Message> parseV1Message(
+            const uint8_t* buffer,
+            size_t buffer_size,
+            size_t start_pos,
+            size_t& bytes_consumed) const noexcept;
+
+        [[nodiscard]] std::optional<Message> parseV2Message(
+            const uint8_t* buffer,
+            size_t buffer_size,
+            size_t start_pos,
+            size_t& bytes_consumed) const noexcept;
+
     public:
         explicit BufferParser(const MessageSet& message_set) noexcept;
 
         /**
-         * @brief Parse a single MAVLink message from a byte buffer
-         * 
+         * @brief Parse a single MAVLink message (v1 or v2) from a byte buffer
+         *
+         * Scans the buffer for the first MAVLink magic byte (0xFE for v1, 0xFD for
+         * v2), then attempts to parse a complete, CRC-valid message starting there.
+         *
          * @param buffer Pointer to the buffer containing MAVLink data
          * @param buffer_size Size of the buffer in bytes
          * @param bytes_consumed Output parameter indicating how many bytes were consumed
          * @return Optional Message if parsing was successful, std::nullopt otherwise
          */
         [[nodiscard]] std::optional<Message> parseMessage(
-            const uint8_t* buffer, 
-            size_t buffer_size, 
+            const uint8_t* buffer,
+            size_t buffer_size,
             size_t& bytes_consumed) const noexcept;
     };
 

--- a/src/BufferParser.cpp
+++ b/src/BufferParser.cpp
@@ -1,35 +1,35 @@
 /****************************************************************************
- * 
+ *
  * Copyright (c) 2023, libmav development team
  * All rights reserved.
- * 
- * Redistribution and use in source and binary forms, with or without 
- * modification, are permitted provided that the following conditions 
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
  * are met:
- * 
- * 1. Redistributions of source code must retain the above copyright 
+ *
+ * 1. Redistributions of source code must retain the above copyright
  *    notice, this list of conditions and the following disclaimer.
- * 2. Redistributions in binary form must reproduce the above copyright 
- *    notice, this list of conditions and the following disclaimer in 
- *    the documentation and/or other materials provided with the 
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
  *    distribution.
- * 3. Neither the name libmav nor the names of its contributors may be 
- *    used to endorse or promote products derived from this software 
+ * 3. Neither the name libmav nor the names of its contributors may be
+ *    used to endorse or promote products derived from this software
  *    without specific prior written permission.
- * 
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS 
- * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT 
- * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS 
- * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE 
- * COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, 
- * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, 
- * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS 
- * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED 
- * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT 
- * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN 
- * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE 
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+ * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
  * POSSIBILITY OF SUCH DAMAGE.
- * 
+ *
  ****************************************************************************/
 
 #include "mav/BufferParser.h"
@@ -42,19 +42,30 @@
 
 namespace mav {
 
-    BufferParser::BufferParser(const MessageSet& message_set) noexcept : 
+    // MAVLink magic bytes
+    static constexpr uint8_t MAVLINK_V1_MAGIC = 0xFE;
+    static constexpr uint8_t MAVLINK_V2_MAGIC = 0xFD;
+
+    // MAVLink v1 wire format constants
+    // [magic(1), len(1), seq(1), sysid(1), compid(1), msgid(1), payload(N), crc(2)]
+    static constexpr int V1_HEADER_SIZE = 6;
+    static constexpr int V1_CHECKSUM_SIZE = 2;
+
+    BufferParser::BufferParser(const MessageSet& message_set) noexcept :
         _message_set(message_set) {}
 
     std::optional<Message> BufferParser::parseMessage(
-        const uint8_t* buffer, 
-        size_t buffer_size, 
+        const uint8_t* buffer,
+        size_t buffer_size,
         size_t& bytes_consumed) const noexcept {
 
         bytes_consumed = 0;
 
-        // Look for MAVLink v2 magic byte
+        // Scan for the first MAVLink magic byte (v1 or v2)
         size_t start_pos = 0;
-        while (start_pos < buffer_size && buffer[start_pos] != 0xFD) {
+        while (start_pos < buffer_size &&
+               buffer[start_pos] != MAVLINK_V2_MAGIC &&
+               buffer[start_pos] != MAVLINK_V1_MAGIC) {
             start_pos++;
         }
 
@@ -63,21 +74,34 @@ namespace mav {
             return std::nullopt;
         }
 
-        // Check if we have enough bytes for complete header
+        if (buffer[start_pos] == MAVLINK_V2_MAGIC) {
+            return parseV2Message(buffer, buffer_size, start_pos, bytes_consumed);
+        } else {
+            return parseV1Message(buffer, buffer_size, start_pos, bytes_consumed);
+        }
+    }
+
+    std::optional<Message> BufferParser::parseV2Message(
+        const uint8_t* buffer,
+        size_t buffer_size,
+        size_t start_pos,
+        size_t& bytes_consumed) const noexcept {
+
+        // Check if we have enough bytes for complete v2 header
         if (start_pos + MessageDefinition::HEADER_SIZE > buffer_size) {
-            bytes_consumed = start_pos; // Consumed bytes before magic byte, not including it
+            bytes_consumed = start_pos; // Consumed bytes before magic, not including it
             return std::nullopt;
         }
 
         // Parse header
         std::array<uint8_t, MessageDefinition::MAX_MESSAGE_SIZE> backing_memory{};
         std::memcpy(backing_memory.data(), buffer + start_pos, MessageDefinition::HEADER_SIZE);
-        
+
         Header header{backing_memory.data()};
         const bool message_is_signed = header.isSigned();
-        const int wire_length = MessageDefinition::HEADER_SIZE + header.len() + 
-                              MessageDefinition::CHECKSUM_SIZE +
-                              (message_is_signed ? MessageDefinition::SIGNATURE_SIZE : 0);
+        const int wire_length = MessageDefinition::HEADER_SIZE + header.len() +
+                                MessageDefinition::CHECKSUM_SIZE +
+                                (message_is_signed ? MessageDefinition::SIGNATURE_SIZE : 0);
 
         // Check if we have the complete message
         if (start_pos + static_cast<size_t>(wire_length) > buffer_size) {
@@ -87,7 +111,7 @@ namespace mav {
 
         // Copy the complete message
         std::memcpy(backing_memory.data(), buffer + start_pos, static_cast<size_t>(wire_length));
-        
+
         const int crc_offset = MessageDefinition::HEADER_SIZE + header.len();
 
         // Get message definition
@@ -112,10 +136,90 @@ namespace mav {
         }
 
         // Create Message object
-        // For BufferParser, we use a default ConnectionPartner since we don't have network info
-        ConnectionPartner partner{0, 0, false}; // Default address=0, port=0, not UART
+        ConnectionPartner partner{0, 0, false};
         bytes_consumed = start_pos + static_cast<size_t>(wire_length);
-        
+
+        return Message::_instantiateFromMemory(definition, partner, crc_offset, std::move(backing_memory));
+    }
+
+    std::optional<Message> BufferParser::parseV1Message(
+        const uint8_t* buffer,
+        size_t buffer_size,
+        size_t start_pos,
+        size_t& bytes_consumed) const noexcept {
+
+        // MAVLink v1 header: [magic(1), len(1), seq(1), sysid(1), compid(1), msgid(1)]
+        // Check if we have enough bytes for the complete v1 header
+        if (start_pos + static_cast<size_t>(V1_HEADER_SIZE) > buffer_size) {
+            bytes_consumed = start_pos; // Consumed bytes before magic, not including it
+            return std::nullopt;
+        }
+
+        const uint8_t payload_len = buffer[start_pos + 1];
+        const int wire_length = V1_HEADER_SIZE + payload_len + V1_CHECKSUM_SIZE;
+
+        // Check if we have the complete message
+        if (start_pos + static_cast<size_t>(wire_length) > buffer_size) {
+            bytes_consumed = start_pos; // Wait for more data
+            return std::nullopt;
+        }
+
+        const uint8_t seq    = buffer[start_pos + 2];
+        const uint8_t sysid  = buffer[start_pos + 3];
+        const uint8_t compid = buffer[start_pos + 4];
+        const uint8_t msgid  = buffer[start_pos + 5]; // v1: 8-bit message ID
+
+        // Get message definition
+        auto definition_opt = _message_set.getMessageDefinition(static_cast<int>(msgid));
+        if (!definition_opt) {
+            // Unknown message, skip it
+            bytes_consumed = start_pos + static_cast<size_t>(wire_length);
+            return std::nullopt;
+        }
+        auto& definition = definition_opt.get();
+
+        // Validate CRC.
+        // v1 CRC covers bytes [1..V1_HEADER_SIZE-1+payload_len] relative to start_pos,
+        // i.e., everything after the magic byte up through the last payload byte.
+        CRC crc;
+        crc.accumulate(
+            buffer + start_pos + 1,
+            buffer + start_pos + V1_HEADER_SIZE + payload_len);
+        crc.accumulate(definition.crcExtra());
+
+        const size_t crc_pos = start_pos + static_cast<size_t>(V1_HEADER_SIZE) + payload_len;
+        const uint16_t crc_received = static_cast<uint16_t>(buffer[crc_pos]) |
+                                      (static_cast<uint16_t>(buffer[crc_pos + 1]) << 8);
+
+        if (crc_received != crc.crc16()) {
+            // CRC error, skip this message
+            bytes_consumed = start_pos + static_cast<size_t>(wire_length);
+            return std::nullopt;
+        }
+
+        // Convert to v2 wire format in backing_memory so Message::_instantiateFromMemory
+        // can be reused. v2 header is 10 bytes; payload starts at offset HEADER_SIZE.
+        std::array<uint8_t, MessageDefinition::MAX_MESSAGE_SIZE> backing_memory{};
+        backing_memory[0] = MAVLINK_V2_MAGIC; // magic (converted)
+        backing_memory[1] = payload_len;
+        backing_memory[2] = 0;      // incompat flags (none in v1)
+        backing_memory[3] = 0;      // compat flags  (none in v1)
+        backing_memory[4] = seq;
+        backing_memory[5] = sysid;
+        backing_memory[6] = compid;
+        backing_memory[7] = msgid;  // low byte of 24-bit msgid
+        backing_memory[8] = 0;      // mid byte
+        backing_memory[9] = 0;      // high byte
+        // Copy payload starting at v2 header offset
+        std::memcpy(
+            backing_memory.data() + MessageDefinition::HEADER_SIZE,
+            buffer + start_pos + V1_HEADER_SIZE,
+            payload_len);
+
+        const int crc_offset = MessageDefinition::HEADER_SIZE + payload_len;
+        bytes_consumed = start_pos + static_cast<size_t>(wire_length);
+
+        ConnectionPartner partner{0, 0, false};
         return Message::_instantiateFromMemory(definition, partner, crc_offset, std::move(backing_memory));
     }
 

--- a/tests/BufferParser.cpp
+++ b/tests/BufferParser.cpp
@@ -35,10 +35,40 @@
 #include "mav/BufferParser.h"
 #include "mav/MessageSet.h"
 #include "mav/Message.h"
+#include "mav/utils.h"
 #include <vector>
 #include <cstring>
 
 using namespace mav;
+
+// Build a valid MAVLink v1 wire packet.
+// v1 layout: [0xFE, len, seq, sysid, compid, msgid(8-bit), payload..., crc_lo, crc_hi]
+// CRC covers bytes [1..5+len] (everything except the magic byte) plus crc_extra.
+static std::vector<uint8_t> buildV1Packet(
+    uint8_t sysid, uint8_t compid, uint8_t msgid, uint8_t seq,
+    const std::vector<uint8_t>& payload, uint8_t crc_extra)
+{
+    std::vector<uint8_t> pkt;
+    pkt.push_back(0xFE);
+    pkt.push_back(static_cast<uint8_t>(payload.size()));
+    pkt.push_back(seq);
+    pkt.push_back(sysid);
+    pkt.push_back(compid);
+    pkt.push_back(msgid);
+    pkt.insert(pkt.end(), payload.begin(), payload.end());
+
+    CRC crc;
+    // Accumulate bytes starting after the magic byte
+    for (size_t i = 1; i < pkt.size(); ++i) {
+        crc.accumulate(pkt[i]);
+    }
+    crc.accumulate(crc_extra);
+
+    const uint16_t c = crc.crc16();
+    pkt.push_back(static_cast<uint8_t>(c & 0xFF));
+    pkt.push_back(static_cast<uint8_t>((c >> 8) & 0xFF));
+    return pkt;
+}
 
 TEST_CASE("BufferParser basic functionality") {
     MessageSet message_set;
@@ -283,5 +313,192 @@ TEST_CASE("BufferParser multiple messages in buffer") {
         uint8_t counter2;
         CHECK(parsed2->get("counter", counter2) == MessageResult::Success);
         CHECK(counter2 == 20);
+    }
+}
+// ── MAVLink v1 tests ──────────────────────────────────────────────────────────
+
+static const char* V1_TEST_XML = R""""(
+<mavlink>
+    <messages>
+        <message id="42" name="V1_TEST_MSG">
+            <field type="uint8_t" name="field_a">Field A</field>
+            <field type="uint8_t" name="field_b">Field B</field>
+        </message>
+    </messages>
+</mavlink>
+)"""";
+
+TEST_CASE("BufferParser MAVLink v1 basic parsing") {
+    MessageSet message_set;
+    REQUIRE(message_set.addFromXMLString(V1_TEST_XML) == MessageSetResult::Success);
+
+    // Obtain the crc_extra from the definition (same for v1 and v2)
+    auto def_opt = message_set.getMessageDefinition(42);
+    REQUIRE(def_opt);
+    const uint8_t crc_extra = def_opt.get().crcExtra();
+
+    BufferParser parser(message_set);
+
+    SUBCASE("Parse a valid v1 packet") {
+        // field_a=0xAA, field_b=0xBB; payload is in wire order (both uint8_t, no reordering)
+        auto pkt = buildV1Packet(1, 1, 42, 0, {0xAA, 0xBB}, crc_extra);
+
+        size_t consumed = 0;
+        auto msg = parser.parseMessage(pkt.data(), pkt.size(), consumed);
+
+        REQUIRE(msg.has_value());
+        CHECK(consumed == pkt.size());
+        CHECK(msg->name() == "V1_TEST_MSG");
+        CHECK(msg->id() == 42);
+
+        // Verify header fields are correctly extracted
+        CHECK(msg->header().systemId() == 1);
+        CHECK(msg->header().componentId() == 1);
+
+        // Verify payload fields
+        uint8_t a, b;
+        CHECK(msg->get("field_a", a) == MessageResult::Success);
+        CHECK(msg->get("field_b", b) == MessageResult::Success);
+        CHECK(a == 0xAA);
+        CHECK(b == 0xBB);
+    }
+
+    SUBCASE("v1 packet with bad CRC is rejected") {
+        auto pkt = buildV1Packet(1, 1, 42, 0, {0x01, 0x02}, crc_extra);
+        // Corrupt the CRC bytes
+        pkt[pkt.size() - 2] ^= 0xFF;
+        pkt[pkt.size() - 1] ^= 0xFF;
+
+        size_t consumed = 0;
+        auto msg = parser.parseMessage(pkt.data(), pkt.size(), consumed);
+
+        CHECK_FALSE(msg.has_value());
+        CHECK(consumed == pkt.size()); // Entire packet is consumed/skipped
+    }
+
+    SUBCASE("v1 packet with unknown message ID is skipped") {
+        // msgid=99 is not in the MessageSet
+        auto pkt = buildV1Packet(1, 1, 99, 0, {0xDE, 0xAD}, 0x00);
+
+        size_t consumed = 0;
+        auto msg = parser.parseMessage(pkt.data(), pkt.size(), consumed);
+
+        CHECK_FALSE(msg.has_value());
+        CHECK(consumed == pkt.size());
+    }
+
+    SUBCASE("Incomplete v1 header returns nullopt and waits") {
+        // Only 4 bytes — not even a full 6-byte v1 header
+        uint8_t truncated[] = {0xFE, 0x02, 0x00, 0x01};
+
+        size_t consumed = 0;
+        auto msg = parser.parseMessage(truncated, sizeof(truncated), consumed);
+
+        CHECK_FALSE(msg.has_value());
+        CHECK(consumed == 0); // Should stop at magic byte, not advance past it
+    }
+
+    SUBCASE("v1 header present but payload incomplete") {
+        // Full header but only 1 of 2 payload bytes present
+        auto pkt = buildV1Packet(1, 1, 42, 0, {0xAA, 0xBB}, crc_extra);
+        // Trim to header + 1 payload byte (omit second payload byte and CRC)
+        const size_t partial_size = 6 + 1; // V1_HEADER_SIZE + 1
+
+        size_t consumed = 0;
+        auto msg = parser.parseMessage(pkt.data(), partial_size, consumed);
+
+        CHECK_FALSE(msg.has_value());
+        CHECK(consumed == 0); // Hold at magic byte waiting for the rest
+    }
+
+    SUBCASE("Garbage bytes before v1 packet are skipped") {
+        auto pkt = buildV1Packet(1, 1, 42, 0, {0x11, 0x22}, crc_extra);
+        std::vector<uint8_t> buf = {0x00, 0x11, 0x22, 0x33}; // garbage
+        buf.insert(buf.end(), pkt.begin(), pkt.end());
+
+        size_t consumed = 0;
+        auto msg = parser.parseMessage(buf.data(), buf.size(), consumed);
+
+        REQUIRE(msg.has_value());
+        CHECK(msg->name() == "V1_TEST_MSG");
+        CHECK(consumed == 4 + pkt.size()); // 4 garbage bytes + full packet
+    }
+}
+
+TEST_CASE("BufferParser mixed v1 and v2 messages") {
+    MessageSet message_set;
+    auto r1 = message_set.addFromXMLString(V1_TEST_XML);
+    auto r2 = message_set.addFromXMLString(R""""(
+<mavlink>
+    <messages>
+        <message id="100" name="V2_TEST_MSG">
+            <field type="uint16_t" name="counter">Counter</field>
+        </message>
+    </messages>
+</mavlink>
+)"""");
+    REQUIRE(r1 == MessageSetResult::Success);
+    REQUIRE(r2 == MessageSetResult::Success);
+
+    auto v1_def = message_set.getMessageDefinition(42);
+    REQUIRE(v1_def);
+    auto v1_pkt = buildV1Packet(1, 1, 42, 0, {0xAA, 0xBB}, v1_def.get().crcExtra());
+
+    // Build a v2 message
+    auto v2_msg_opt = message_set.create("V2_TEST_MSG");
+    REQUIRE(v2_msg_opt.has_value());
+    auto v2_msg = v2_msg_opt.value();
+    v2_msg.set("counter", static_cast<uint16_t>(1234));
+    auto v2_size_opt = v2_msg.finalize(1, mav::Identifier{1, 1});
+    REQUIRE(v2_size_opt.has_value());
+    const uint8_t* v2_wire = v2_msg.data();
+    const size_t v2_size = static_cast<size_t>(v2_size_opt.value());
+
+    SUBCASE("v1 followed by v2") {
+        std::vector<uint8_t> buf(v1_pkt);
+        buf.insert(buf.end(), v2_wire, v2_wire + v2_size);
+
+        BufferParser parser(message_set);
+
+        size_t c1 = 0;
+        auto msg1 = parser.parseMessage(buf.data(), buf.size(), c1);
+        REQUIRE(msg1.has_value());
+        CHECK(msg1->name() == "V1_TEST_MSG");
+        CHECK(c1 == v1_pkt.size());
+
+        size_t c2 = 0;
+        auto msg2 = parser.parseMessage(buf.data() + c1, buf.size() - c1, c2);
+        REQUIRE(msg2.has_value());
+        CHECK(msg2->name() == "V2_TEST_MSG");
+        CHECK(c2 == v2_size);
+
+        uint16_t counter;
+        CHECK(msg2->get("counter", counter) == MessageResult::Success);
+        CHECK(counter == 1234);
+    }
+
+    SUBCASE("v2 followed by v1") {
+        std::vector<uint8_t> buf(v2_wire, v2_wire + v2_size);
+        buf.insert(buf.end(), v1_pkt.begin(), v1_pkt.end());
+
+        BufferParser parser(message_set);
+
+        size_t c1 = 0;
+        auto msg1 = parser.parseMessage(buf.data(), buf.size(), c1);
+        REQUIRE(msg1.has_value());
+        CHECK(msg1->name() == "V2_TEST_MSG");
+        CHECK(c1 == v2_size);
+
+        size_t c2 = 0;
+        auto msg2 = parser.parseMessage(buf.data() + c1, buf.size() - c1, c2);
+        REQUIRE(msg2.has_value());
+        CHECK(msg2->name() == "V1_TEST_MSG");
+        CHECK(c2 == v1_pkt.size());
+
+        uint8_t a, b;
+        CHECK(msg2->get("field_a", a) == MessageResult::Success);
+        CHECK(msg2->get("field_b", b) == MessageResult::Success);
+        CHECK(a == 0xAA);
+        CHECK(b == 0xBB);
     }
 }


### PR DESCRIPTION
## Problem

`BufferParser::parseMessage` only scanned for the MAVLink v2 magic byte (`0xFD`). Any message sent as MAVLink v1 (`0xFE`) was silently dropped, because the scan loop skipped `0xFE` as noise.

This caused a real-world bug in MAVSDK: `MavlinkDirect` subscribers connected via serial never received messages that ArduPilot (and other autopilots) send as MAVLink v1 by default — `HEARTBEAT`, `SYS_STATUS`, `GPS_RAW_INT`, `MISSION_CURRENT`, etc. The same messages were received fine over UDP (where a GCS relay had already promoted them to v2) and by `MavlinkPassthrough` (which uses the standard C MAVLink parser that handles both versions). See mavlink/MAVSDK#2862.

## Changes

**`src/BufferParser.cpp`**
- `parseMessage()` now scans for either magic byte (`0xFE` or `0xFD`) and dispatches to a version-specific helper.
- `parseV1Message()` validates the v1 CRC (computed over the header and payload, skipping only the magic byte), then promotes the packet into a v2-layout `backing_memory` so that `Message::_instantiateFromMemory` can be reused without changes. Callers receive a uniform `Message` object regardless of wire version.
- `parseV2Message()` is the existing logic, extracted into a private helper.

**`include/mav/BufferParser.h`**
- Updated docstring to mention v1 support.
- Added `private` declarations for the two new helpers.

**`tests/BufferParser.cpp`**
- Added `buildV1Packet()` helper that constructs a correctly CRC'd v1 wire packet given field bytes and the message's `crcExtra`.
- New test cases:
  - Valid v1 packet parsed with correct field values and header metadata
  - Bad CRC rejected; entire packet consumed
  - Unknown message ID skipped; entire packet consumed
  - Incomplete v1 header (< 6 bytes) — returns nullopt, `bytes_consumed = 0`
  - Partial payload — returns nullopt, `bytes_consumed = 0`
  - Garbage bytes before v1 packet are skipped correctly
  - Mixed buffer: v1 then v2 parsed in sequence
  - Mixed buffer: v2 then v1 parsed in sequence

All 13 test cases pass.